### PR TITLE
fix: correctly set QueueURL if S3 Bucket provided inline

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -252,6 +252,7 @@ func TestSendMessage(t *testing.T) {
 			assert.Equal(t, "12", *params.MessageAttributes["ExtendedPayloadSize"].StringValue)
 			assert.Equal(t, "hi", *params.MessageAttributes["testing_attribute"].StringValue)
 			assert.Equal(t, getDefaultS3Pointer("override_bucket", *key), *params.MessageBody)
+			assert.Equal(t, "testing_url", *params.QueueUrl)
 
 			return true
 		}),
@@ -340,6 +341,7 @@ func TestSendMessageBatch(t *testing.T) {
 		"SendMessageBatch",
 		mock.Anything,
 		mock.MatchedBy(func(params *sqs.SendMessageBatchInput) bool {
+			assert.Equal(t, "testing_url", *params.QueueUrl)
 			assert.Len(t, params.Entries, 2)
 			assert.Equal(t, "entry_1", *params.Entries[0].Id)
 			assert.Equal(t, "entry_2", *params.Entries[1].Id)


### PR DESCRIPTION
In the case where a QueueURL was joined with an S3Bucket in `SendMessage` or `SendMessageBatch`, the S3 Bucket was not properly removed before passing through to the SQS client, resulting in some errors. This PR resolves this bug and modifies test cases to verify the functionality.