### PR TITLE
feat(obj-prefix): enable prefixes on object keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,7 +135,7 @@ func WithPointerClass(pointerClass string) ClientOption {
 	}
 }
 
-// WithObjectPrefix attach a prefix to the object key (prefix/uuid)
+// WithObjectPrefix attaches a prefix to the object key (prefix/uuid)
 func WithObjectPrefix(prefix string) ClientOption {
 	return func(c *Client) error {
 		if !validObjectNameRegex.MatchString(prefix) {

--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ var (
 	jsonMarshal     = json.Marshal
 	ErrObjectPrefix = errors.New("object prefix contains invalid characters")
 )
+var validObjectNameRegex = regexp.MustCompile("^[0-9a-zA-Z!_.*'()-]+$")
 
 type S3Client interface {
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
@@ -136,9 +137,8 @@ func WithPointerClass(pointerClass string) ClientOption {
 
 // WithObjectPrefix attach a prefix to the object key (prefix/uuid)
 func WithObjectPrefix(prefix string) ClientOption {
-	r, _ := regexp.Compile("^[0-9a-zA-Z!_.*'()-]+$")
 	return func(c *Client) error {
-		if !r.MatchString(prefix) {
+		if !validObjectNameRegex.MatchString(prefix) {
 			return ErrObjectPrefix
 		}
 		c.objectPrefix = prefix

--- a/client_test.go
+++ b/client_test.go
@@ -246,23 +246,32 @@ func TestGenerateS3Key(t *testing.T) {
 
 func TestWithObjectPrefix(t *testing.T) {
 	invalidPrefixes := []string{"../test", "./test", "tes&", "te$t", "testñ", "te@st", "test=", "test;", "test:", "+test", "te st", "te,st", "test?", "te\\st", "test{", "test^", "test}", "te`st", "]test", "test\"", "test>", "test]", "test~", "test<", "te#st", "|test"}
-	for _, prefix := range invalidPrefixes {
-		_, err := New(
-			nil,
-			nil,
-			WithObjectPrefix(prefix),
-		)
-		assert.Equal(t, err, ErrObjectPrefix)
-	}
 	validPrefixes := []string{"test0", "test", "TESt", "te!st", "te-st", "te_st", "te.st", "test*", "'test'", "(test)"}
-	for _, prefix := range validPrefixes {
-		c, err := New(
-			nil,
-			nil,
-			WithObjectPrefix(prefix),
-		)
-		assert.Nil(t, err)
-		assert.Equal(t, c.objectPrefix, prefix)
+
+	tests := []struct {
+		name        string
+		prefixes    []string
+		expectedErr error
+	}{
+		{"invalid prefixes", invalidPrefixes, ErrObjectPrefix},
+		{"valid prefixes", validPrefixes, nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, prefix := range test.prefixes {
+				c, err := New(
+					nil,
+					nil,
+					WithObjectPrefix(prefix),
+				)
+				if test.expectedErr == nil {
+					assert.Equal(t, c.objectPrefix, prefix)
+				} else {
+					assert.Equal(t, err, ErrObjectPrefix)
+				}
+			}
+		})
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -225,7 +225,7 @@ func TestS3PointerUnmarshalInvalidLength(t *testing.T) {
 }
 
 func TestWithObjectPrefix(t *testing.T) {
-	invalidPrefixes := []string{"../test", "./test", "tes&", "te$t", "testñ", "te@st", "test=", "test;", "test:", "+test", "te st", "te,st", "test?"}
+	invalidPrefixes := []string{"../test", "./test", "tes&", "te$t", "testñ", "te@st", "test=", "test;", "test:", "+test", "te st", "te,st", "test?", "te\\st", "test{", "test^", "test}", "te`st", "]test", "test\"", "test>", "test]", "test~", "test<", "te#st", "|test"}
 	for _, prefix := range invalidPrefixes {
 		_, err := New(
 			nil,

--- a/client_test.go
+++ b/client_test.go
@@ -268,7 +268,7 @@ func TestWithObjectPrefix(t *testing.T) {
 				if test.expectedErr == nil {
 					assert.Equal(t, c.objectPrefix, prefix)
 				} else {
-					assert.Equal(t, err, test.expectedErr)
+					assert.Equal(t, test.expectedErr, err)
 				}
 			}
 		})

--- a/client_test.go
+++ b/client_test.go
@@ -225,12 +225,12 @@ func TestS3PointerUnmarshalInvalidLength(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid pointer format, expected length 2, but received [3]")
 }
 
-func TestGenerateS3Key(t *testing.T) {
+func TestS3Key(t *testing.T) {
 	uuid := uuid.New().String()
 	tests := []struct {
 		name          string
 		prefix        string
-		uuid          string
+		filename      string
 		expectedS3Key string
 	}{
 		{"with prefix", "test", uuid, fmt.Sprintf("%s/%s", "test", uuid)},
@@ -238,8 +238,16 @@ func TestGenerateS3Key(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s3key := generateS3Key(test.prefix, test.uuid)
-			assert.Equal(t, test.expectedS3Key, s3key)
+			var c *Client
+			var err error
+			if test.prefix != "" {
+				c, err = New(nil, nil, WithObjectPrefix(test.prefix))
+			} else {
+				c, err = New(nil, nil)
+			}
+			assert.Nil(t, err)
+			s3Key := c.s3Key(test.filename)
+			assert.Equal(t, test.expectedS3Key, s3Key)
 		})
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"strings"
 	"testing"
@@ -222,6 +223,25 @@ func TestS3PointerUnmarshalInvalidLength(t *testing.T) {
 	var p s3Pointer
 	err := p.UnmarshalJSON(str)
 	assert.ErrorContains(t, err, "invalid pointer format, expected length 2, but received [3]")
+}
+
+func TestGenerateS3Key(t *testing.T) {
+	uuid := uuid.New().String()
+	tests := []struct {
+		name          string
+		prefix        string
+		uuid          string
+		expectedS3Key string
+	}{
+		{"with prefix", "test", uuid, fmt.Sprintf("%s/%s", "test", uuid)},
+		{"without prefix", "", uuid, uuid},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s3key := generateS3Key(test.prefix, test.uuid)
+			assert.Equal(t, test.expectedS3Key, s3key)
+		})
+	}
 }
 
 func TestWithObjectPrefix(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -268,7 +268,7 @@ func TestWithObjectPrefix(t *testing.T) {
 				if test.expectedErr == nil {
 					assert.Equal(t, c.objectPrefix, prefix)
 				} else {
-					assert.Equal(t, err, ErrObjectPrefix)
+					assert.Equal(t, err, test.expectedErr)
 				}
 			}
 		})


### PR DESCRIPTION
These changes enable us to attach a prefix to the object key:
Before: uuid
Now: prefix/uuid

We only accept prefixes that match with the safe characters defined in this documentation:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html