### PR TITLE
Regenerate `aws-sdk` SQS interface (v1.26.0)

### DIFF
--- a/sqs.go
+++ b/sqs.go
@@ -1,4 +1,4 @@
-// Generated from service/sqs/v1.24.7
+// Generated from service/sqs/v1.26.0
 
 package sqsextendedclient
 


### PR DESCRIPTION
New SQS client version released from [`aws-sdk-go-v2`](https://github.com/aws/aws-sdk-go-v2) - `v1.26.0`

##### See [full changelog](https://github.com/aws/aws-sdk-go-v2/blob/main/service/sqs/CHANGELOG.md).