### PR TITLE
Regenerate `aws-sdk` SQS interface (v1.29.7)

### DIFF
--- a/sqs.go
+++ b/sqs.go
@@ -1,4 +1,4 @@
-// Generated from service/sqs/v1.29.6
+// Generated from service/sqs/v1.29.7
 
 package sqsextendedclient
 


### PR DESCRIPTION
New SQS client version released from [`aws-sdk-go-v2`](https://github.com/aws/aws-sdk-go-v2) - `v1.29.7`

##### See [full changelog](https://github.com/aws/aws-sdk-go-v2/blob/service/sqs/v1.29.7/service/sqs/CHANGELOG.md).